### PR TITLE
move listicon_item back into controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -807,6 +807,18 @@ class ApplicationController < ActionController::Base
     root
   end
 
+  def listicon_item(view, id = nil)
+    id = @id if id.nil?
+
+    if @targets_hash
+      @targets_hash[id] # Get the record from the view
+    else
+      klass = view.db.constantize
+      klass.find(id)    # Read the record from the db
+    end
+  end
+  public :listicon_item
+
   def get_host_for_vm(vm)
     @hosts = [vm.host] if vm.host
   end

--- a/app/helpers/host_helper/textual_summary.rb
+++ b/app/helpers/host_helper/textual_summary.rb
@@ -4,6 +4,7 @@ module HostHelper::TextualSummary
   include TextualMixins::TextualOsInfo
   include TextualMixins::TextualVmmInfo
   include TextualMixins::TextualPowerState
+  include TextualMixins::TextualProtected
   # TODO: Determine if DoNav + url_for + :title is the right way to do links, or should it be link_to with :title
 
   #
@@ -16,7 +17,7 @@ module HostHelper::TextualSummary
       %i[
         hostname region ipaddress ipmi_ipaddress ipmi_enabled hypervisor_hostname custom_1 vmm_info vmm_version vmm_buildnumber model asset_tag service_tag osinfo
         power_state lockdown_mode maintenance_mode devices network storage_adapters num_cpu num_cpu_cores
-        cpu_cores_per_socket memory guid
+        cpu_cores_per_socket memory protected guid
       ]
     )
   end

--- a/app/helpers/textual_mixins/textual_protected.rb
+++ b/app/helpers/textual_mixins/textual_protected.rb
@@ -1,0 +1,6 @@
+module TextualMixins::TextualProtected
+  def textual_protected
+    protected = @record.has_policies
+    {:label => _("Protected"), :icon => protected ? "fa fa-shield" : "fa fa-remove", :value => protected.to_s}
+  end
+end

--- a/app/helpers/vm_cloud_helper/textual_summary.rb
+++ b/app/helpers/vm_cloud_helper/textual_summary.rb
@@ -9,6 +9,7 @@ module VmCloudHelper::TextualSummary
   include TextualMixins::TextualOsInfo
   include TextualMixins::TextualPatches
   include TextualMixins::TextualPowerState
+  include TextualMixins::TextualProtected
   include TextualMixins::TextualRegion
   include TextualMixins::TextualScanHistory
   include TextualMixins::VmCommon
@@ -26,7 +27,7 @@ module VmCloudHelper::TextualSummary
         load_balancer_health_check_state osinfo architecture
       ] + (@record.type == 'ManageIQ::Providers::Amazon::CloudManager::Vm' ? %i[] : %i[snapshots]) +
       %i[
-        advanced_settings resources guid virtualization_type root_device_type ems_ref
+        advanced_settings resources guid virtualization_type root_device_type protected ems_ref
       ]
     )
   end

--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -9,6 +9,7 @@ module VmHelper::TextualSummary
   include TextualMixins::TextualOsInfo
   include TextualMixins::TextualPatches
   include TextualMixins::TextualPowerState
+  include TextualMixins::TextualProtected
   include TextualMixins::TextualRegion
   include TextualMixins::TextualScanHistory
   include TextualMixins::TextualDevices
@@ -27,7 +28,7 @@ module VmHelper::TextualSummary
       %i[
         id name region server description hostname ipaddress mac_address custom_1 container host_platform
         tools_status load_balancer_health_check_state osinfo devices cpu_affinity snapshots
-        advanced_settings resources guid storage_profile
+        advanced_settings resources guid storage_profile protected
       ]
     )
   end

--- a/lib/gtl_formatter.rb
+++ b/lib/gtl_formatter.rb
@@ -76,8 +76,8 @@ class GtlFormatter
         "prov_type" => :service_template_format,
       },
     }
-    cols.push(format_icon_column(view, row, options[:clickable])) if VIEW_WITH_CUSTOM_ICON.include?(view.db)
-    record = listicon_item(view, row['id'])
+    cols.push(format_icon_column(view, row, controller, options[:clickable])) if VIEW_WITH_CUSTOM_ICON.include?(view.db)
+    record = controller.listicon_item(view, row['id'])
     view.col_order.each_with_index do |col, col_idx|
       next if view.column_is_hidden?(col, controller)
 
@@ -121,8 +121,8 @@ class GtlFormatter
     cols
   end
 
-  def self.format_icon_column(view, row, clickable)
-    item = listicon_item(view, row['id'])
+  def self.format_icon_column(view, row, controller, clickable)
+    item = controller.listicon_item(view, row['id'])
     icon, icon2, image = fonticon_or_fileicon(item)
 
     # Clickable should be false only when it's explicitly set to false
@@ -130,17 +130,6 @@ class GtlFormatter
      :image => ActionController::Base.helpers.image_path(image.to_s),
      :icon  => icon,
      :icon2 => icon2}.compact
-  end
-
-  def self.listicon_item(view, id = nil)
-    id = @id if id.nil?
-
-    if @targets_hash
-      @targets_hash[id] # Get the record from the view
-    else
-      klass = view.db.constantize
-      klass.find(id)    # Read the record from the db
-    end
   end
 
   def self.fonticon_or_fileicon(item)

--- a/lib/gtl_formatter.rb
+++ b/lib/gtl_formatter.rb
@@ -7,7 +7,6 @@ class GtlFormatter
   ]
 
   COLUMN_WITH_ICON = {
-    'has_policies'           => 'has_policies_image',
     'authentication_status'  => 'authentication_status_image',
     'last_compliance_status' => 'last_compliance_status_image',
     'normalized_state'       => 'normalized_state_image'
@@ -178,10 +177,6 @@ class GtlFormatter
 
   def self.normalized_state_image(item)
     NORMALIZED_STATE_ICON[item.normalized_state]
-  end
-
-  def self.has_policies_image(item)
-    item.has_policies ? "fa fa-shield" : "pficon pficon-pending-2"
   end
 
   def self.cloud_manager_template_format(value)

--- a/product/views/Host.yaml
+++ b/product/views/Host.yaml
@@ -26,7 +26,6 @@ cols:
 - v_total_vms
 - v_total_miq_templates
 - vmm_product
-- has_policies
 - normalized_state
 - last_compliance_status
 - last_scan_on
@@ -53,7 +52,6 @@ col_order:
 - v_total_vms
 - v_total_miq_templates
 - vmm_product
-- has_policies
 - normalized_state
 - last_compliance_status
 - last_scan_on
@@ -69,7 +67,6 @@ headers:
 - Total VMs
 - Total Templates
 - Platform
-- Protected
 - Power
 - Compliant
 - Last Analysis Time

--- a/product/views/InstanceOrImage.yaml
+++ b/product/views/InstanceOrImage.yaml
@@ -22,7 +22,6 @@ cols:
 - name
 - ems_cluster_name
 - last_compliance_status
-- has_policies
 - v_total_snapshots
 - last_scan_on
 - region_description
@@ -50,7 +49,6 @@ col_order:
 - host.name
 - storage.name
 - last_compliance_status
-- has_policies
 - v_total_snapshots
 - last_scan_on
 - region_description
@@ -62,7 +60,6 @@ headers:
 - Host
 - Datastore
 - Compliant
-- Protected
 - Total Snapshots
 - Last Analysis Time
 - Region

--- a/product/views/ManageIQ_Providers_CloudManager_Template-all_vms_and_templates.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager_Template-all_vms_and_templates.yaml
@@ -21,7 +21,6 @@ db: TemplateCloud
 cols:
 - name
 - last_compliance_status
-- has_policies
 - allocated_disk_storage
 - last_scan_on
 
@@ -41,7 +40,6 @@ include_for_find:
 col_order:
 - name
 - last_compliance_status
-- has_policies
 - allocated_disk_storage
 - hardware.bitness
 - last_scan_on
@@ -50,7 +48,6 @@ col_order:
 headers:
 - Name
 - Compliant
-- Protected
 - Allocated Size
 - Architecture
 - Last Analysis Time

--- a/product/views/ManageIQ_Providers_CloudManager_Template.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager_Template.yaml
@@ -21,7 +21,6 @@ db: TemplateCloud
 cols:
 - name
 - last_compliance_status
-- has_policies
 - allocated_disk_storage
 - last_scan_on
 - region_description
@@ -50,7 +49,6 @@ col_order:
 - ext_management_system.name
 - image?
 - last_compliance_status
-- has_policies
 - allocated_disk_storage
 - hardware.bitness
 - hardware.virtualization_type
@@ -64,7 +62,6 @@ headers:
 - Provider
 - Type
 - Compliant
-- Protected
 - Allocated Size
 - Architecture
 - Virtualization Type

--- a/product/views/ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates.yaml
@@ -22,7 +22,6 @@ cols:
 - name
 - ipaddresses
 - last_compliance_status
-- has_policies
 - allocated_disk_storage
 - last_scan_on
 - normalized_state
@@ -52,7 +51,6 @@ col_order:
 - flavor.name
 - ipaddresses
 - last_compliance_status
-- has_policies
 - allocated_disk_storage
 - hardware.bitness
 - last_scan_on
@@ -65,7 +63,6 @@ headers:
 - Flavor
 - IP Addresses
 - Compliant
-- Protected
 - Allocated Size
 - Architecture
 - Last Analysis Time

--- a/product/views/ManageIQ_Providers_CloudManager_Vm-vms.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager_Vm-vms.yaml
@@ -22,7 +22,6 @@ cols:
 - name
 - ipaddresses
 - last_compliance_status
-- has_policies
 - allocated_disk_storage
 - last_scan_on
 - normalized_state
@@ -52,7 +51,6 @@ col_order:
 - flavor.name
 - ipaddresses
 - last_compliance_status
-- has_policies
 - allocated_disk_storage
 - hardware.bitness
 - last_scan_on
@@ -65,7 +63,6 @@ headers:
 - Flavor
 - IP Addresses
 - Compliant
-- Protected
 - Allocated Size
 - Architecture
 - Last Analysis Time

--- a/product/views/ManageIQ_Providers_CloudManager_Vm.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager_Vm.yaml
@@ -22,7 +22,6 @@ cols:
 - name
 - ipaddresses
 - last_compliance_status
-- has_policies
 - allocated_disk_storage
 - last_scan_on
 - load_balancer_health_check_state
@@ -58,7 +57,6 @@ col_order:
 - flavor.name
 - ipaddresses
 - last_compliance_status
-- has_policies
 - allocated_disk_storage
 - hardware.bitness
 - last_scan_on
@@ -74,7 +72,6 @@ headers:
 - Flavor
 - IP Addresses
 - Compliant
-- Protected
 - Allocated Size
 - Architecture
 - Last Analysis Time

--- a/product/views/MiqTemplate-all_miq_templates.yaml
+++ b/product/views/MiqTemplate-all_miq_templates.yaml
@@ -22,7 +22,6 @@ cols:
 - name
 - ems_cluster_name
 - last_compliance_status
-- has_policies
 - v_total_snapshots
 - last_scan_on
 
@@ -49,7 +48,6 @@ col_order:
 - host.name
 - storage.name
 - last_compliance_status
-- has_policies
 - v_total_snapshots
 - last_scan_on
 
@@ -60,7 +58,6 @@ headers:
 - Host
 - Datastore
 - Compliant
-- Protected
 - Total Snapshots
 - Last Analysis Time
 

--- a/product/views/MiqTemplate.yaml
+++ b/product/views/MiqTemplate.yaml
@@ -21,7 +21,6 @@ db: MiqTemplate
 cols:
 - name
 - last_compliance_status
-- has_policies
 - v_total_snapshots
 - allocated_disk_storage
 - last_scan_on
@@ -42,7 +41,6 @@ include_for_find:
 col_order:
 - name
 - last_compliance_status
-- has_policies
 - v_total_snapshots
 - allocated_disk_storage
 - last_scan_on
@@ -52,7 +50,6 @@ col_order:
 headers:
 - Name
 - Compliant
-- Protected
 - Total Snapshots
 - Allocated Size
 - Last Analysis Time

--- a/product/views/Vm-all_vms.yaml
+++ b/product/views/Vm-all_vms.yaml
@@ -22,7 +22,6 @@ cols:
 - name
 - ems_cluster_name
 - last_compliance_status
-- has_policies
 - v_total_snapshots
 - last_scan_on
 - normalized_state
@@ -51,7 +50,6 @@ col_order:
 - host.name
 - storage.name
 - last_compliance_status
-- has_policies
 - v_total_snapshots
 - last_scan_on
 
@@ -63,7 +61,6 @@ headers:
 - Host
 - Datastore
 - Compliant
-- Protected
 - Total Snapshots
 - Last Analysis Time
 

--- a/product/views/Vm.yaml
+++ b/product/views/Vm.yaml
@@ -22,7 +22,6 @@ cols:
 - name
 - ipaddresses
 - last_compliance_status
-- has_policies
 - v_total_snapshots
 - allocated_disk_storage
 - last_scan_on
@@ -45,7 +44,6 @@ col_order:
 - normalized_state
 - ipaddresses
 - last_compliance_status
-- has_policies
 - v_total_snapshots
 - allocated_disk_storage
 - last_scan_on
@@ -57,7 +55,6 @@ headers:
 - Power State
 - IP Addresses
 - Compliant
-- Protected
 - Total Snapshots
 - Allocated Size
 - Last Analysis Time

--- a/product/views/VmOrTemplate-all_archived.yaml
+++ b/product/views/VmOrTemplate-all_archived.yaml
@@ -22,7 +22,6 @@ cols:
 - name
 - ems_cluster_name
 - last_compliance_status
-- has_policies
 - v_total_snapshots
 - allocated_disk_storage
 - last_scan_on
@@ -50,7 +49,6 @@ col_order:
 - host.name
 - storage.name
 - last_compliance_status
-- has_policies
 - v_total_snapshots
 - allocated_disk_storage
 - last_scan_on
@@ -62,7 +60,6 @@ headers:
 - Host
 - Datastore
 - Compliant
-- Protected
 - Total Snapshots
 - Allocated Size
 - Last Analysis Time

--- a/product/views/VmOrTemplate-all_orphaned.yaml
+++ b/product/views/VmOrTemplate-all_orphaned.yaml
@@ -22,7 +22,6 @@ cols:
 - name
 - ems_cluster_name
 - last_compliance_status
-- has_policies
 - v_total_snapshots
 - allocated_disk_storage
 - last_scan_on
@@ -50,7 +49,6 @@ col_order:
 - host.name
 - storage.name
 - last_compliance_status
-- has_policies
 - v_total_snapshots
 - allocated_disk_storage
 - last_scan_on
@@ -62,7 +60,6 @@ headers:
 - Host
 - Datastore
 - Compliant
-- Protected
 - Total Snapshots
 - Allocated Size
 - Last Analysis Time

--- a/product/views/VmOrTemplate-all_vms_and_templates.yaml
+++ b/product/views/VmOrTemplate-all_vms_and_templates.yaml
@@ -23,7 +23,6 @@ cols:
 - ipaddresses
 - ems_cluster_name
 - last_compliance_status
-- has_policies
 - v_total_snapshots
 - allocated_disk_storage
 - last_scan_on
@@ -54,7 +53,6 @@ col_order:
 - ipaddresses
 - storage.name
 - last_compliance_status
-- has_policies
 - v_total_snapshots
 - allocated_disk_storage
 - last_scan_on
@@ -68,7 +66,6 @@ headers:
 - IP Addresses
 - Datastore
 - Compliant
-- Protected
 - Total Snapshots
 - Allocated Size
 - Last Analysis Time

--- a/product/views/VmOrTemplate.yaml
+++ b/product/views/VmOrTemplate.yaml
@@ -23,7 +23,6 @@ cols:
 - ipaddresses
 - ems_cluster_name
 - last_compliance_status
-- has_policies
 - v_total_snapshots
 - allocated_disk_storage
 - last_scan_on
@@ -59,7 +58,6 @@ col_order:
 - ipaddresses
 - storage.name
 - last_compliance_status
-- has_policies
 - v_total_snapshots
 - allocated_disk_storage
 - last_scan_on
@@ -75,7 +73,6 @@ headers:
 - IP Addresses
 - Datastore
 - Compliant
-- Protected
 - Total Snapshots
 - Allocated Size
 - Last Analysis Time


### PR DESCRIPTION
I like moving `listicon_item` into the gtl formatter.
Unfortunately, the cache `@targets_hash` is in the controller.

Your PR has made a tremendous improvement, as you can see from the before / after. I simply tweaked it to help get the queries back down.


Applies to ManageIQ/manageiq-ui-classic#7189

Thanks Harpreet

|       ms |query |  qry ms |     rows |`comments`
|      ---:|  ---:|     ---:|      ---:| ---
|  6,630.5 |   14 | 4,731.1 |       50 |before 7189
|    970.5 |  173 |   196.3 |      169 |after 7189
|    569.8 |   13 |    54.5 |       49 |after this pr
|   41.3%  |  92% | 72.2%   |    71%   |improvement